### PR TITLE
resourceServerAuthToken - solution for issue #4

### DIFF
--- a/appAuthHelper.js
+++ b/appAuthHelper.js
@@ -17,6 +17,7 @@
          * @param {string} config.revocationEndpoint - Full URL to the OP revocation endpoint
          * @param {string} config.endSessionEndpoint - Full URL to the OP end session endpoint
          * @param {object} config.resourceServers - Map of resource server urls to the scopes which they require. Map values are space-delimited list of scopes requested by this RP for use with this RS
+         * @param {string} config.resourceServerAuthToken - [accessToken] - Indicate which token to use for the Authentication Bearer token. Options are 'accessToken' or 'idToken'. Defaults to accessToken
          * @param {function} config.interactionRequiredHandler - optional function to be called anytime interaction is required. When not provided, default behavior is to redirect the current window to the authorizationEndpoint
          * @param {function} config.tokensAvailableHandler - function to be called every time tokens are available - both initially and upon renewal
          * @param {number} config.renewCooldownPeriod [1] - Minimum time (in seconds) between requests to the authorizationEndpoint for token renewal attempts
@@ -54,6 +55,12 @@
 
 
             this.appAuthConfig.resourceServers = config.resourceServers || {};
+
+            this.appAuthConfig.resourceServerAuthToken = config.resourceServerAuthToken || "accessToken";
+            if (!(config.resourceServerAuthToken in ["accessToken", "idToken"])) {
+                this.appAuthConfig.resourceServerAuthToken = "accessToken";
+            }
+
             this.appAuthConfig.clientId = config.clientId;
             this.appAuthConfig.scopes = (this.appAuthConfig.oidc ? ["openid"] : [])
                 .concat(

--- a/appAuthHelper.js
+++ b/appAuthHelper.js
@@ -56,10 +56,7 @@
 
             this.appAuthConfig.resourceServers = config.resourceServers || {};
 
-            this.appAuthConfig.resourceServerAuthToken = config.resourceServerAuthToken || "accessToken";
-            if (!(config.resourceServerAuthToken in ["accessToken", "idToken"])) {
-                this.appAuthConfig.resourceServerAuthToken = "accessToken";
-            }
+            this.appAuthConfig.resourceServerAuthToken = (["accessToken", "idToken"].includes(config.resourceServerAuthToken)) ? config.resourceServerAuthToken : "accessToken";
 
             this.appAuthConfig.clientId = config.clientId;
             this.appAuthConfig.scopes = (this.appAuthConfig.oidc ? ["openid"] : [])

--- a/appAuthHelperBundle.js
+++ b/appAuthHelperBundle.js
@@ -18,6 +18,7 @@
          * @param {string} config.revocationEndpoint - Full URL to the OP revocation endpoint
          * @param {string} config.endSessionEndpoint - Full URL to the OP end session endpoint
          * @param {object} config.resourceServers - Map of resource server urls to the scopes which they require. Map values are space-delimited list of scopes requested by this RP for use with this RS
+         * @param {string} config.resourceServerAuthToken - [accessToken] - Indicate which token to use for the Authentication Bearer token. Options are 'accessToken' or 'idToken'. Defaults to accessToken
          * @param {function} config.interactionRequiredHandler - optional function to be called anytime interaction is required. When not provided, default behavior is to redirect the current window to the authorizationEndpoint
          * @param {function} config.tokensAvailableHandler - function to be called every time tokens are available - both initially and upon renewal
          * @param {number} config.renewCooldownPeriod [1] - Minimum time (in seconds) between requests to the authorizationEndpoint for token renewal attempts
@@ -55,6 +56,12 @@
 
 
             this.appAuthConfig.resourceServers = config.resourceServers || {};
+
+            this.appAuthConfig.resourceServerAuthToken = config.resourceServerAuthToken || "accessToken";
+            if (!(config.resourceServerAuthToken in ["accessToken", "idToken"])) {
+                this.appAuthConfig.resourceServerAuthToken = "accessToken";
+            }
+
             this.appAuthConfig.clientId = config.clientId;
             this.appAuthConfig.scopes = (this.appAuthConfig.oidc ? ["openid"] : [])
                 .concat(

--- a/appAuthHelperBundle.js
+++ b/appAuthHelperBundle.js
@@ -57,10 +57,7 @@
 
             this.appAuthConfig.resourceServers = config.resourceServers || {};
 
-            this.appAuthConfig.resourceServerAuthToken = config.resourceServerAuthToken || "accessToken";
-            if (!(config.resourceServerAuthToken in ["accessToken", "idToken"])) {
-                this.appAuthConfig.resourceServerAuthToken = "accessToken";
-            }
+            this.appAuthConfig.resourceServerAuthToken = (["accessToken", "idToken"].includes(config.resourceServerAuthToken)) ? config.resourceServerAuthToken : "accessToken";
 
             this.appAuthConfig.clientId = config.clientId;
             this.appAuthConfig.scopes = (this.appAuthConfig.oidc ? ["openid"] : [])

--- a/appAuthHelperFetchTokens.js
+++ b/appAuthHelperFetchTokens.js
@@ -118,7 +118,11 @@
                                 }
 
                                 if (currentResourceServer !== null) {
-                                    tokens[currentResourceServer] = token_endpoint_response[appAuthConfig.resourceServerAuthToken];
+                                    if (appAuthConfig.resourceServers[currentResourceServer] === "openid" && appAuthConfig.resourceServerAuthToken === "idToken") {
+                                        tokens[currentResourceServer] = token_endpoint_response.idToken;
+                                    } else {
+                                        tokens[currentResourceServer] = token_endpoint_response.accessToken;
+                                    }
                                 } else {
                                     tokens.accessToken = token_endpoint_response.accessToken;
                                 }

--- a/appAuthHelperFetchTokens.js
+++ b/appAuthHelperFetchTokens.js
@@ -118,7 +118,7 @@
                                 }
 
                                 if (currentResourceServer !== null) {
-                                    tokens[currentResourceServer] = token_endpoint_response.accessToken;
+                                    tokens[currentResourceServer] = token_endpoint_response[appAuthConfig.resourceServerAuthToken];
                                 } else {
                                     tokens.accessToken = token_endpoint_response.accessToken;
                                 }

--- a/appAuthHelperFetchTokensBundle.js
+++ b/appAuthHelperFetchTokensBundle.js
@@ -119,7 +119,7 @@
                                 }
 
                                 if (currentResourceServer !== null) {
-                                    tokens[currentResourceServer] = token_endpoint_response.accessToken;
+                                    tokens[currentResourceServer] = token_endpoint_response[appAuthConfig.resourceServerAuthToken];
                                 } else {
                                     tokens.accessToken = token_endpoint_response.accessToken;
                                 }

--- a/appAuthHelperFetchTokensBundle.js
+++ b/appAuthHelperFetchTokensBundle.js
@@ -119,7 +119,11 @@
                                 }
 
                                 if (currentResourceServer !== null) {
-                                    tokens[currentResourceServer] = token_endpoint_response[appAuthConfig.resourceServerAuthToken];
+                                    if (appAuthConfig.resourceServers[currentResourceServer] === "openid" && appAuthConfig.resourceServerAuthToken === "idToken") {
+                                        tokens[currentResourceServer] = token_endpoint_response.idToken;
+                                    } else {
+                                        tokens[currentResourceServer] = token_endpoint_response.accessToken;
+                                    }
                                 } else {
                                     tokens.accessToken = token_endpoint_response.accessToken;
                                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appauthhelper",
-  "version": "0.0.2",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1387,9 +1387,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -2160,7 +2160,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appauthhelper",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Wrapper for AppAuthJS to assist with silent token acquisition and renewal",
   "main": "appAuthHelper.js",
   "scripts": {


### PR DESCRIPTION
This PR adds the `resourceServerAuthToken` config option to the appAuthHelper enable usage of idToken instead of accessToken for resourceServer requests.

If a resourceServer's scope is set to "openid" and `resourceServerAuthToken` is set to "idToken", then the resourceServer token in the IndexedDB will be set to the idToken instead of the accessToken.